### PR TITLE
7 encrypt account sensible fields with activerecordencryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore environment variables file
+.env
+
 # Ignore bundler config.
 /.bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.3.4"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.2", ">= 7.0.2.3"
+gem "rails", "~> 7.0.8.4", ">= 7.0.3.2"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
@@ -42,7 +42,10 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails'
 
-  # Library for setting up Ruby objects as test data.
+  # Load environment variables from `.env`.
+  gem 'dotenv'
+
+  # Setting up Ruby objects as test data.
   gem 'factory_bot_rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    dotenv (3.1.2)
     drb (2.2.1)
     dry-cli (1.1.0)
     erubi (1.13.0)
@@ -234,6 +235,7 @@ DEPENDENCIES
   base64
   bigdecimal
   debug
+  dotenv
   drb
   factory_bot_rails
   foreman
@@ -242,7 +244,7 @@ DEPENDENCIES
   pg
   pry
   puma (~> 5.0)
-  rails (~> 7.0.2, >= 7.0.2.3)
+  rails (~> 7.0.8.4, >= 7.0.3.2)
   rspec-rails
   sprockets-rails
   tzinfo-data

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,22 @@ dev: ## Execute application in development mode
 	bin/dev
 	make stop
 
-.PHONY: stop
-stop: ## Stop development's containers
-	$(call DOCKER_COMPOSE,  stop)
+.PHONY: dc-down
+dc-down: ## Stops containers and removes containers, networks, volumes, and images of this project
+	$(call DOCKER_COMPOSE, -f docker-compose-test.yml down)
+	$(call DOCKER_COMPOSE, down)
 
 .PHONY: test
 test: ## Execute automated tests. Require postgres (execute `make run-test-db` into another terminal)
 	RAILS_ENV=test bundle exec rake db:create
 	RAILS_ENV=test bundle exec rake db:schema:load
 	rspec spec
+
+.PHONY: setup-db
+setup-db: ## Setup database for development mode
+	$(call DOCKER_COMPOSE, -f docker-compose.yml up -d)
+	rails db:migrate
+	rails db:seed
 
 .PHONY: run-test-db
 run-test-db: ## Execute postgres DB to run automated tests

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ rails db:migrate
 rails db:seed
 ```
 
+3. Setup ActiveRecord Encryption to protect sensitive data:
+
+Generate and copy the encryption credentials
+```bash
+rails db:encryption:init
+```
+
+Open the credentials file, and add the encryption creadentials
+```bash
+rails credentials:edit
+```
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,7 @@ bundle install
 npm install
 ```
 
-2. Setup database
-
-```bash
-# Run postgres DB with development database
-make run-dev-db
-
-# Run migrations and seeds
-rails db:migrate
-rails db:seed
-```
-
-3. Setup ActiveRecord Encryption to protect sensitive data:
+2. Setup ActiveRecord Encryption to protect sensitive data:
 
 Generate and copy the encryption credentials
 ```bash
@@ -44,6 +33,16 @@ rails db:encryption:init
 Open the credentials file, and add the encryption creadentials
 ```bash
 rails credentials:edit
+```
+
+3. Setup database
+
+```bash
+# Clean old containers
+make dc-down
+
+# Run create database, run migrations and seeds
+make setup-db
 ```
 
 ## Run

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,14 +2,24 @@ class Account < ApplicationRecord
   belongs_to  :customer
   belongs_to  :currency
 
-  before_validation :set_default_customer
+  attribute :account_number, :string, default: -> { SecureRandom.uuid }
+  attribute :balance, :decimal, default: -> { 0.0 }
+  enum status: { active: 0 }, _default: :active
 
-  validates :name, :status, :currency, :balance, presence: true
+  #****************************   Encryption   *******************************
+  # Deterministic encryption to allow searches by account number, which will be a common use case.
+  encrypts :account_number, deterministic: true
+
+  # Non-deterministic encryption for increased security on balances, as we won't be using queries to search by balance.
+  encrypts :balance, deterministic: false
+
+  #****************************   Validations  *******************************
+  before_validation :set_default_customer
+  validates :name, :status, :currency, :balance, :account_number, presence: true
   validates :name, uniqueness: { scope: :customer_id }
+  validates :account_number, uniqueness: true
   validates :balance, numericality: { greater_than_or_equal_to: 0 }
 
-  # Add more statuses as needed
-  enum status: { active: 0 }, _default: :active
 
   def is_default?
     self.customer.default_account_id == self.id
@@ -17,9 +27,8 @@ class Account < ApplicationRecord
 
   private
 
-  # Hardcoded customer for demo purposes
+  # Assign a hard-coded customer for demo purposes
   def set_default_customer
     self.customer = Customer.find(1) if Rails.env.development? && self.customer.nil?
   end
-
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,11 +38,5 @@ module MorakiBankAccounts
     config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
     config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
     config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
-    config.active_record.encryption.support_unencrypted_data = true
-
-    # Load the YAML column configuration to allow the type cast in encrypted columns
-    # This configuration is disabled by default, to backguard compatibility with Rails versions lower than 7.0.3.2 (Not our case)
-    # Related info: https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
-    config.active_record.yaml_column_permitted_classes = [BigDecimal]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,16 @@ module MorakiBankAccounts
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Load the encryption configuration
+    config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
+    config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
+    config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+    config.active_record.encryption.support_unencrypted_data = true
+
+    # Load the YAML column configuration to allow the type cast in encrypted columns
+    # This configuration is disabled by default, to backguard compatibility with Rails versions lower than 7.0.3.2 (Not our case)
+    # Related info: https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
+    config.active_record.yaml_column_permitted_classes = [BigDecimal]
   end
 end

--- a/db/migrate/20240729222513_create_accounts.rb
+++ b/db/migrate/20240729222513_create_accounts.rb
@@ -5,10 +5,10 @@ class CreateAccounts < ActiveRecord::Migration[7.0]
     create_table :accounts do |t|
       t.belongs_to :customer, foreign_key: true
 
-      t.string  :name, null: false
-      t.uuid    :account_number, :uuid, null: false, default: 'gen_random_uuid()'
-      t.integer  :status, null: false, default: 0
-      t.decimal :balance, null: false, precision: 8, scale: 2, default: 0.0
+      t.string    :name, null: false
+      t.string    :account_number, null: false, index: { unique: true }
+      t.string    :balance, null: false
+      t.integer   :status, null: false, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,13 +18,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_01_222512) do
   create_table "accounts", force: :cascade do |t|
     t.bigint "customer_id"
     t.string "name", null: false
-    t.uuid "account_number", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.string "account_number", null: false
+    t.string "balance", null: false
     t.integer "status", default: 0, null: false
-    t.decimal "balance", precision: 8, scale: 2, default: "0.0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "currency_id", null: false
+    t.index ["account_number"], name: "index_accounts_on_account_number", unique: true
     t.index ["currency_id"], name: "index_accounts_on_currency_id"
     t.index ["customer_id"], name: "index_accounts_on_customer_id"
   end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Accounts", type: :request do
 
       expect(inertia.props[:account][:id]).to eq(account.id)
       expect(inertia.props[:account][:customer_id]).to eq(account.customer_id)
-      expect(inertia.props[:account][:uuid]).to eq(account.uuid)
+      expect(inertia.props[:account][:account_number]).to eq(account.account_number)
       expect(inertia.props[:account][:name]).to eq(account.name)
       expect(inertia.props[:account][:currency][:code]).to eq(account.currency.code)
       expect(inertia.props[:account][:status]).to eq(account.status)
@@ -46,7 +46,7 @@ RSpec.describe "Accounts", type: :request do
 
   describe "#create" do
     let!(:account)            { create(:account, customer: customer) }
-    let!(:valid_attributes)   {{customer_id: customer.id, name: "My new account", balance: 0, currency_id: account.currency.id, status: "active"}}
+    let!(:valid_attributes)   {{customer_id: customer.id, name: "My new account", balance: 100.12, currency_id: account.currency.id, status: "active"}}
 
     it "creates a new account" do
       expect {
@@ -54,8 +54,10 @@ RSpec.describe "Accounts", type: :request do
       }.to change(Account, :count).by(1)
 
       # check the record
-      expect(Account.last.name).to  eq("My new account")
-      expect(Account.last.id).to    eq(customer.reload.default_account_id)
+      created_account = Account.last
+      expect(created_account.name).to     eq("My new account")
+      expect(created_account.id).to       eq(customer.reload.default_account_id)
+      expect(created_account.balance).to  eq(100.12)
 
       # check redirection
       assert_redirected_to account_url(Account.last)


### PR DESCRIPTION
Related issue -> https://github.com/leobz/moraki_bank_accounts/issues/7

## Resume
Encrypt sensible data of Accounts: `balance` and `account_number`.

## Changes
- Migrate balance and account_number to encrypted columns
- Apply ActiveRecordEncryption using environment variables
- Update doc


## Screenshots

![Screenshot from 2024-08-03 00-37-45](https://github.com/user-attachments/assets/eeeffc71-89d7-4bf1-a947-743dc3a5a14e)

